### PR TITLE
Discontinue sequence if nonzero exit code is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ modules:
 echo node_modules/@scoped/* | bulk -c "npm install --production"
 ```
 
+#### Exit any time a nonzero exit code occurs
+Runs all commands but exits on the first nonzero exit code.
+
+``` bash
+linklocal list -r | bulk -c 'npm test' -e
+```
+
 ## License
 
 MIT. See [LICENSE.md](http://github.com/timoxley/bulk/blob/master/LICENSE.md) for details.

--- a/bulk.js
+++ b/bulk.js
@@ -10,12 +10,13 @@ var parse = require('shell-quote').parse
 var fs = require('fs')
 
 var argv = minimist(process.argv, {
-  boolean: ['bail', 'chdir'],
-  default: { 'bail': false, 'chdir': true },
+  boolean: ['bail', 'chdir', 'exit' ],
+  default: { 'bail': false, 'chdir': true, 'exit': false },
   alias: {
     b: 'bail',
     d: 'chdir',
-    c: 'command'
+    c: 'command',
+    e: 'exit'
   }
 })
 
@@ -64,7 +65,10 @@ function execSeries(argv) {
       next(err)
       next = noop
     })
-    .on('exit', function() {
+    .on('exit', function(code) {
+      if(argv['exit'] && code !== 0) {
+        return process.exit(code);
+      }
       next()
       next = noop
     })


### PR DESCRIPTION
Hi I made a quick patch to quit running commands if you pass in `--exit` to the command. I'm using `bulk` to run `npm test` on all subdirectories but it doesn't fail when one of packages' tests fail. But now I can just do: `linklocal list -r | bulk -c 'npm test' -e`.